### PR TITLE
UI-507: fix: add Inter font import

### DIFF
--- a/packages/celeste-tokens/src/generate.ts
+++ b/packages/celeste-tokens/src/generate.ts
@@ -12,6 +12,7 @@ register(StyleDictionary);
 
 const fonts = `
 @import url('https://fonts.googleapis.com/css2?family=Cairo:wght@200..1000&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 `;
 
 function prependFonts(path: string): void {


### PR DESCRIPTION
### QA Steps
* [ ] `cd` into `celeste-tokens`
* [ ] Run `pnpm build`
* [ ] Check the generated `tokens.css` file
* [ ] You should see [Inter](https://fonts.google.com/specimen/Inter) font import right after Cairo's font import