### PR TITLE
refactor: handle input reactivity

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5041,8 +5041,8 @@ packages:
   vue-component-type-helpers@2.2.0:
     resolution: {integrity: sha512-cYrAnv2me7bPDcg9kIcGwjJiSB6Qyi08+jLDo9yuvoFQjzHiPTzML7RnkJB1+3P6KMsX/KbCD4QE3Tv/knEllw==}
 
-  vue-component-type-helpers@3.0.1:
-    resolution: {integrity: sha512-j23mCB5iEbGsyIhnVdXdWUOg+UdwmVxpKnYYf2j+4ppCt5VSFXKjwu9YFt0QYxUaf5G99PuHsVfRScjHCRSsGQ==}
+  vue-component-type-helpers@2.2.10:
+    resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -6224,7 +6224,7 @@ snapshots:
       storybook: 9.0.4(@testing-library/dom@10.4.0)(prettier@3.4.2)
       type-fest: 2.19.0
       vue: 3.5.13(typescript@5.8.3)
-      vue-component-type-helpers: 3.0.1
+      vue-component-type-helpers: 2.2.10
 
   '@stylistic/eslint-plugin@2.12.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
@@ -10561,7 +10561,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.0: {}
 
-  vue-component-type-helpers@3.0.1: {}
+  vue-component-type-helpers@2.2.10: {}
 
   vue-demi@0.14.10(vue@3.5.13(typescript@5.8.3)):
     dependencies:


### PR DESCRIPTION
## Syntax
```vue
<script setup lang="ts">
const text = ref("piw")
</script>

<template>
  <input v-model="text" placeholder="Placeholder text..." />
</template>
```
## Output
| Before | After |
|--------|--------|
| <img width="300" alt="Screenshot 2025-07-08 at 14 58 59" src="https://github.com/user-attachments/assets/699fd821-2a4b-4eff-aa14-3abc97c161ee" /> | <img width="300" alt="Screenshot 2025-07-08 at 14 59 12" src="https://github.com/user-attachments/assets/cf1a5c55-a727-4acf-a47b-04b91270d207" /> | 

> [!NOTE]
> Things like `defaultValue` and `@input` are now available for use